### PR TITLE
Removes the repositoriesMode setting. 

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
     repositories {
         google()
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
K/N adds an Ivy repository dynamically to download the K/N compiler, so we cannot enforce repositories to be declared in `settings.gradle.kts`.