### PR TITLE
Avoid type error by renaming Package.product to Package.storeProduct

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -103,7 +103,7 @@ public final class io/shortway/kobankat/Package_androidKt {
 	public static final fun getOfferingIdentifier (Lcom/revenuecat/purchases/Package;)Ljava/lang/String;
 	public static final fun getPackageType (Lcom/revenuecat/purchases/Package;)Lcom/revenuecat/purchases/PackageType;
 	public static final fun getPresentedOfferingContext (Lcom/revenuecat/purchases/Package;)Lcom/revenuecat/purchases/PresentedOfferingContext;
-	public static final fun getProduct (Lcom/revenuecat/purchases/Package;)Lio/shortway/kobankat/models/StoreProduct;
+	public static final fun getStoreProduct (Lcom/revenuecat/purchases/Package;)Lio/shortway/kobankat/models/StoreProduct;
 }
 
 public final class io/shortway/kobankat/PresentedOfferingContext_androidKt {

--- a/core/src/androidMain/kotlin/io/shortway/kobankat/Package.android.kt
+++ b/core/src/androidMain/kotlin/io/shortway/kobankat/Package.android.kt
@@ -13,7 +13,7 @@ public actual val Package.identifier: String
     get() = identifier
 public actual val Package.packageType: PackageType
     get() = packageType.toPackageType()
-public actual val Package.product: StoreProduct
+public actual val Package.storeProduct: StoreProduct
     get() = StoreProduct(product)
 public actual val Package.presentedOfferingContext: PresentedOfferingContext
     get() = presentedOfferingContext

--- a/core/src/commonMain/kotlin/io/shortway/kobankat/Package.kt
+++ b/core/src/commonMain/kotlin/io/shortway/kobankat/Package.kt
@@ -7,7 +7,7 @@ import io.shortway.kobankat.models.StoreProduct
  * [/docs/entitlements](https://docs.revenuecat.com/docs/entitlements).
  * @property identifier Unique identifier for this package. Can be one a predefined package type or a custom one.
  * @property packageType Package type for the product. Will be one of [PackageType].
- * @property product [StoreProduct] assigned to this package.
+ * @property storeProduct [StoreProduct] assigned to this package.
  * @property presentedOfferingContext [PresentedOfferingContext] from which this package was obtained.
  * @property offeringIdentifier offering this package was returned from.
  */
@@ -15,7 +15,7 @@ public expect class Package
 
 public expect val Package.identifier: String
 public expect val Package.packageType: PackageType
-public expect val Package.product: StoreProduct
+public expect val Package.storeProduct: StoreProduct
 public expect val Package.presentedOfferingContext: PresentedOfferingContext
 public expect val Package.offeringIdentifier: String
 

--- a/core/src/iosMain/kotlin/io/shortway/kobankat/Package.ios.kt
+++ b/core/src/iosMain/kotlin/io/shortway/kobankat/Package.ios.kt
@@ -20,7 +20,7 @@ public actual val Package.identifier: String
     get() = identifier()
 public actual val Package.packageType: PackageType
     get() = packageType().toPackageType()
-public actual val Package.product: StoreProduct
+public actual val Package.storeProduct: StoreProduct
     get() = storeProduct()
 public actual val Package.presentedOfferingContext: PresentedOfferingContext
     get() = presentedOfferingContext()


### PR DESCRIPTION
Closes #48. 